### PR TITLE
Add prerequisite for doc generation

### DIFF
--- a/source/_posts/2016-03-31-documentation-with-exdoc.md
+++ b/source/_posts/2016-03-31-documentation-with-exdoc.md
@@ -19,7 +19,7 @@ end
 
 > You can use Markdown within Elixir `@doc` and `@moduledoc` attributes.
 
-Then, run `mix docs`. 
+Then, run `mix deps.get` to fetch and compile the new modules and generate the project documentation with `mix docs`. 
 An example output is the [official Elixir Docs](http://elixir-lang.org/docs/stable/elixir/).
 
 


### PR DESCRIPTION
I think `mix deps.get` is necessary before generating the docs with the newly added modules. (At least I needed this in both of my projects.) Thank you!