### PR TITLE
Remove redundant dependency

### DIFF
--- a/source/_posts/2016-03-31-documentation-with-exdoc.md
+++ b/source/_posts/2016-03-31-documentation-with-exdoc.md
@@ -12,8 +12,7 @@ To generate documentation from `@doc` and `@moduledoc` attributes in your source
 # config/mix.exs
 
 def deps do
-  [{:ex_doc, "~> 0.11", only: :dev},
-   {:earmark, "~> 0.1", only: :dev}]
+  [{:ex_doc, "~> 0.11", only: :dev}]
 end
 {% endhighlight %}
 


### PR DESCRIPTION
Sorry, I just realized that `ex_doc` is building on `earmark` so the latter would be pulled automatically...