### PR TITLE
fix for duplicate disqus threads

### DIFF
--- a/source/_includes/comments.html
+++ b/source/_includes/comments.html
@@ -11,7 +11,7 @@
       var disqus_shortname = '{{ site.disqus_shortname }}';
       var disqus_identifier = '{{ page.id }}';
       var disqus_title = '{{ page.title }}';
-      var disqus_url = '{{ site.url }}{{ post.url }}';
+      var disqus_url = '{{ site.url }}{{ page.url }}';
       /*var disqus_developer = 1;*/
 
       (function() {


### PR DESCRIPTION
I see that there duplicate disqus threads for all the posts in the site.

When digging into this, I came across this in the [Jekyll](https://jekyllrb.com/docs/posts/) posts documentation: 

> Note that the `post` variable only exists inside the for loop above. If you wish to access the currently-rendering page/posts’s variables (the variables of the post/page that has the for loop in it), use the `page` variable instead.

Consequently, all the posts had blank value for `post.url`. I've changed it to `page.url`.
This should fix the duplicate disqus threads in the site. :)