### PR TITLE
Fix delimiter in split

### DIFF
--- a/source/_posts/2016-05-07-splitting-strings.md
+++ b/source/_posts/2016-05-07-splitting-strings.md
@@ -7,6 +7,6 @@ comments: true
 ---
 
 {% highlight elixir %}
-iex> String.split("Elixir, Antidote, Panacea", ",")
+iex> String.split("Elixir, Antidote, Panacea", ", ")
 ["Elixir", "Antidote", "Panacea"]
 {% endhighlight %}


### PR DESCRIPTION
With `","` as the delimiter, this would produce:
`["Elixir", " Antidote", " Panacea"]` (note the space before Antidote and Panacea).

This PR changes the delimiter to `", "` which is likely how this was intended.
```elixir
iex(2)> String.split("Elixir, Antidote, Panacea", ", ")
["Elixir", "Antidote", "Panacea"]
```