### PR TITLE
Use Task.async_stream on Parallel.pmap

### DIFF
--- a/source/_posts/2016-03-24-parallel-map.md
+++ b/source/_posts/2016-03-24-parallel-map.md
@@ -10,10 +10,10 @@ We define an Elixir function `pmap` using the [Task API](http://elixir-lang.org/
 
 {% highlight elixir %}
 defmodule Parallel do
-  def pmap(collection, func) do
+  def pmap(collection, func, opt \\ []) do
     collection
-    |> Enum.map(&(Task.async(fn -> func.(&1) end)))
-    |> Enum.map(&Task.await/1)
+    |> Task.async_stream(func, opt)
+    |> Enum.map(fn {:ok, res} -> res end)
   end
 end
 {% endhighlight %}
@@ -30,3 +30,13 @@ iex(2)> res = Parallel.pmap 1..10000, &(&1 * &1)
 {% endhighlight %}
 
 In the background, we've spawned 10000 processes to perform the same squaring operation on multiple data points simultaneously. We make use of all the cores and processors on our machine.
+We can also limit the number of processors using the max_concurrent argument.
+
+{% highlight elixir %}
+iex(1)> c("parallel.ex")
+iex(2)> res = Parallel.pmap 1..10000, &(&1 * &1), max_concurrency: 10
+[1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324,
+ 361, 400, 441, 484, 529, 576, 625, 676, 729, 784, 841, 900, 961, 1024, 1089,
+ 1156, 1225, 1296, 1369, 1444, 1521, 1600, 1681, 1764, 1849, 1936, 2025, 2116,
+ 2209, 2304, 2401, 2500, ...]
+{% endhighlight %}


### PR DESCRIPTION
The [`Task.async_stream/3`](https://hexdocs.pm/elixir/Task.html#async_stream/3) provide a better solution to this problem  I think.

Reference:
- https://elixirforum.com/t/when-to-use-pools-vs-tasks/19818/2